### PR TITLE
Replace Darkwing sprite with erik-arcade.gif on /about

### DIFF
--- a/about/about.js
+++ b/about/about.js
@@ -62,39 +62,3 @@
     }
 })();
 
-// Darkwing Duck interactive animation
-document.addEventListener('DOMContentLoaded', function () {
-    const darkwingSprite = document.querySelector('.darkwing-sprite');
-
-    if (darkwingSprite) {
-        function triggerLookAnimation() {
-            // Prevent multiple animations at once
-            if (darkwingSprite.classList.contains('looking')) {
-                return;
-            }
-
-            // Add animation class
-            darkwingSprite.classList.add('looking');
-
-            // Remove class after animation completes
-            setTimeout(() => {
-                darkwingSprite.classList.remove('looking');
-            }, 800); // Match animation duration
-        }
-
-        // Add click/tap event listeners
-        darkwingSprite.addEventListener('click', triggerLookAnimation);
-        darkwingSprite.addEventListener('touchstart', function (e) {
-            e.preventDefault(); // Prevent double-tap zoom
-            triggerLookAnimation();
-        });
-
-        // Add keyboard support (Enter and Space)
-        darkwingSprite.addEventListener('keydown', function (e) {
-            if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                triggerLookAnimation();
-            }
-        });
-    }
-});

--- a/about/index.html
+++ b/about/index.html
@@ -97,9 +97,8 @@
                     </div>
                 </div>
 
-                <img src="../assets/images/darkwing-sprite.png" alt="Darkwing Duck sprite - click or tap to see him look around"
-                    width="100" height="100" data-progressive class="darkwing-sprite" tabindex="0" role="button"
-                    aria-label="Darkwing Duck easter egg - click to animate" loading="lazy" />
+                <img src="../assets/images/erik-arcade.gif" alt="Erik Sagen as an arcade game character"
+                    data-progressive class="erik-arcade" loading="lazy" />
             </div>
 
             <section id="the-journey-so-far" class="career-timeline animate-fade-in">

--- a/about/styles.css
+++ b/about/styles.css
@@ -116,61 +116,11 @@ body[data-theme="light"] .about-intro p:nth-of-type(1) {
 
 /* Remove redundant typography styles */
 
-.darkwing-sprite {
+.erik-arcade {
     display: block;
     margin: var(--space-8) auto;
-    cursor: pointer;
-    transition: transform 0.1s ease;
-    user-select: none;
-    -webkit-user-select: none;
-    -webkit-tap-highlight-color: transparent;
-    border-radius: 8px;
-    padding: 8px;
-}
-
-.darkwing-sprite:hover {
-    transform: scale(1.05);
-}
-
-.darkwing-sprite:focus {
-    outline: 2px solid var(--accent-color);
-    outline-offset: 4px;
-}
-
-@keyframes darkwing-look {
-    0% {
-        transform: rotate(0deg) scale(1);
-    }
-
-    25% {
-        transform: rotate(-15deg) scale(1.1);
-    }
-
-    50% {
-        transform: rotate(15deg) scale(1.1);
-    }
-
-    75% {
-        transform: rotate(-8deg) scale(1.05);
-    }
-
-    100% {
-        transform: rotate(0deg) scale(1);
-    }
-}
-
-.darkwing-sprite.looking {
-    animation: darkwing-look 0.8s ease-in-out;
-}
-
-@media (prefers-reduced-motion: reduce) {
-    .darkwing-sprite.looking {
-        animation: none !important;
-    }
-
-    .darkwing-sprite:hover {
-        transform: none !important;
-    }
+    width: 100px;
+    height: auto;
 }
 
 .reading-section,


### PR DESCRIPTION
Swaps the interactive Darkwing Duck sprite for the static erik-arcade.gif,
renames the class to .erik-arcade, sets width/auto height for the taller
image, and removes all click animation JS and CSS.

https://claude.ai/code/session_01XeWteyApjLbH22BXi77JCc