### PR TITLE
Hotfix: replace Darkwing sprite with erik-arcade.gif on /about

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -98,7 +98,7 @@
                 </div>
 
                 <img src="../assets/images/erik-arcade.gif" alt="Erik Sagen as an arcade game character"
-                    data-progressive class="erik-arcade" loading="lazy" />
+                    class="erik-arcade" loading="lazy" />
             </div>
 
             <section id="the-journey-so-far" class="career-timeline animate-fade-in">


### PR DESCRIPTION
## Summary

- Replaces `darkwing-sprite.png` with `erik-arcade.gif` in the same position on the `/about` page
- Renames class from `.darkwing-sprite` to `.erik-arcade`; sets `width: 100px; height: auto` to accommodate the taller image, centered with `display: block; margin: auto`
- Removes all click/touch/keyboard animation logic and associated CSS (keyframes, hover, focus, `.looking` state)
- Removes `data-progressive` from the GIF (no WebP equivalent) to prevent the progressive image script from wrapping it in an `inline-block` div that was breaking centering
- Both the avatar and erik-arcade images use `loading="lazy"`

## Test plan

- [ ] Visit `/about` and confirm `erik-arcade.gif` appears in place of the Darkwing sprite
- [ ] Confirm the image is horizontally centered below the bio text
- [ ] Confirm no click/tap animation fires on the image
- [ ] Check on mobile that centering and sizing hold up
- [ ] Confirm no console errors related to progressive image loading